### PR TITLE
Nagios/update template to allow flag to specify nrpe plugin directories

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -68,7 +68,7 @@
 - name: NRPE | Install global plugins
   copy:
     src: "{{ item }}"
-    dest: "{{ opt_nrpe_plugins_dir }}/"
+    dest: "{{ opt_nrpe_plugins_dir_path }}/"
     owner: root
     group: root
     mode: "0755"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -68,7 +68,7 @@
 - name: NRPE | Install global plugins
   copy:
     src: "{{ item }}"
-    dest: "{{ nrpe_plugins_dir }}/"
+    dest: "{{ opt_nrpe_plugins_dir }}/"
     owner: root
     group: root
     mode: "0755"

--- a/templates/nrpe_d.cfg.j2
+++ b/templates/nrpe_d.cfg.j2
@@ -1,3 +1,3 @@
 {{ ansible_managed | comment }}
 
-command[{{ item.key }}]={% if item.value.sudo is defined and item.value.sudo == true %}sudo {% endif %}{% if item.value.opt_nrpe_plugins_dir is defined and item.value.opt_nrpe_plugins_dir == true %}{{opt_nrpe_plugins_dir}}{% else %}{{nrpe_plugins_dir}}{% endif %}/{{ item.value.script }} {{ item.value.option | default('') }}
+command[{{ item.key }}]={% if item.value.sudo is defined and item.value.sudo == true %}sudo {% endif %}{% if item.value.opt_nrpe_plugins_dir is defined and item.value.opt_nrpe_plugins_dir == true %}{{opt_nrpe_plugins_dir_path}}{% else %}{{nrpe_plugins_dir}}{% endif %}/{{ item.value.script }} {{ item.value.option | default('') }}

--- a/templates/nrpe_d.cfg.j2
+++ b/templates/nrpe_d.cfg.j2
@@ -1,3 +1,3 @@
 {{ ansible_managed | comment }}
 
-command[{{ item.key }}]={% if item.value.sudo is defined and item.value.sudo == true %}sudo {% endif %}{{ nrpe_plugins_dir }}/{{ item.value.script }} {{ item.value.option | default('') }}
+command[{{ item.key }}]={% if item.value.sudo is defined and item.value.sudo == true %}sudo {% endif %}{% if item.value.opt_nrpe_plugins_dir is defined and item.value.opt_nrpe_plugins_dir == true %}{{opt_nrpe_plugins_dir}}{% else %}{{nrpe_plugins_dir}}{% endif %}/{{ item.value.script }} {{ item.value.option | default('') }}

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -8,6 +8,7 @@ nrpe_user: nrpe
 nrpe_group: nrpe
 nrpe_service: nrpe
 nrpe_plugins_dir: /usr/lib64/nagios/plugins
+opt_nrpe_plugins_dir: /opt/nagios/plugins
 nrpe_dir: /etc/nagios
 
 #

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -8,7 +8,7 @@ nrpe_user: nrpe
 nrpe_group: nrpe
 nrpe_service: nrpe
 nrpe_plugins_dir: /usr/lib64/nagios/plugins
-opt_nrpe_plugins_dir: /opt/nagios/plugins
+opt_nrpe_plugins_dir_path: /opt/nagios/plugins
 nrpe_dir: /etc/nagios
 
 #

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -51,3 +51,4 @@ nrpe_packages:
   - nagios-plugins-uptime
 
 epel_repo: "las_EPEL7_epel7"
+


### PR DESCRIPTION
This allows us to set for each check where the plugins directory is. The example below will change the plugin path to reflect what hte variable opt_nrpe_plugins_dir is set to. Currently /opt/nagios/plugins

Need to put in a pull request for the roles/ISU-Ansible.nrpe/vars/RedHat.yml file as well, but that is managed in the isu-ansible repo, not this role repository. 

    check_ceph_health:
      script: check_ceph_health
      option: --name client.nagios --id nagios --monaddress yak-01 --keyring /etc/nagios/ceph.client.nagios.keyring --detail
      opt_nrpe_plugins_dir: true